### PR TITLE
Update package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,13 +1,13 @@
 /* global Package:readonly, Npm:readonly  */
 Package.describe({
   name: 'tmeasday:check-npm-versions',
-  version: '2.0.0',
+  version: '2.0.1',
   summary: 'Check that required npm packages are installed at the app level',
   git: 'https://github.com/tmeasday/check-npm-versions.git',
   documentation: 'README.md',
 });
 
-Npm.depends({ semver: '6.3.0' }); // 7.x versions are incompatible with Internet Explorer
+Npm.depends({ semver: '7.6.3' });
 
 Package.onUse(function (api) {
   api.versionsFrom(['2.8.0', '3.0.1']);

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 /* global Package:readonly, Npm:readonly  */
 Package.describe({
   name: 'tmeasday:check-npm-versions',
-  version: '2.0.1',
+  version: '2.1.0',
   summary: 'Check that required npm packages are installed at the app level',
   git: 'https://github.com/tmeasday/check-npm-versions.git',
   documentation: 'README.md',


### PR DESCRIPTION
This minor PR upgrades the `semver` dependency to the latest version. The current version used by `check-npm-versions` has [a known security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2022-25883).